### PR TITLE
Extend ECS Service healthcheck grace period

### DIFF
--- a/ecs-bluegreen-lifecycle-hooks/README.md
+++ b/ecs-bluegreen-lifecycle-hooks/README.md
@@ -144,7 +144,7 @@ aws ecs \
     wait services-stable \
     --region $AWS_REGION \
     --cluster $ECS_CLUSTER_NAME \
-    --service $ECS_SERVICE_NAME \
+    --service $ECS_SERVICE_NAME
 ```
 
 ### Update Service with New Task Definition

--- a/ecs-bluegreen-lifecycle-hooks/service_template.json
+++ b/ecs-bluegreen-lifecycle-hooks/service_template.json
@@ -51,6 +51,6 @@
             "assignPublicIp": "DISABLED"
         }
     },
-    "healthCheckGracePeriodSeconds": 30,
+    "healthCheckGracePeriodSeconds": 60,
     "schedulingStrategy": "REPLICA"
 }


### PR DESCRIPTION
Due to the time taken to start the sample application, ALB health checks occasionally fail, resulting in ECS starting new Tasks. This extends the grace period for ALB health checks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
