### PR TITLE
fix: cleanup s3 access log files

### DIFF
--- a/ecs-bluegreen-service-connect/lib/ecs-bluegreen-service-connect-stack.ts
+++ b/ecs-bluegreen-service-connect/lib/ecs-bluegreen-service-connect-stack.ts
@@ -52,7 +52,7 @@ export class EcsBlueGreenServiceConnectStack extends cdk.Stack {
                 }
             ]
         });
-        this.vpc.addFlowLog("FlowLogs",{
+        this.vpc.addFlowLog("FlowLogs", {
             destination: ec2.FlowLogDestination.toCloudWatchLogs(),
             trafficType: ec2.FlowLogTrafficType.REJECT
         });
@@ -119,17 +119,18 @@ export class EcsBlueGreenServiceConnectStack extends cdk.Stack {
             },
             loadBalancerName: 'BlueGreenALB',
             idleTimeout: cdk.Duration.seconds(60)
-            
         });
 
         this.alb.logAccessLogs(new s3.Bucket(this, 'ApplicationLoadBalancerAccessLogs', {
             encryption: s3.BucketEncryption.S3_MANAGED,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
+            autoDeleteObjects: true,
             enforceSSL: true,
             serverAccessLogsBucket: new s3.Bucket(this, 'S3ServerAccessLogs', {
                 encryption: s3.BucketEncryption.S3_MANAGED,
                 removalPolicy: cdk.RemovalPolicy.DESTROY,
                 enforceSSL: true,
+                autoDeleteObjects: true,
             })
         }));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cleanup the ALB access logs when the CloudFormation stack is deleted. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
