### PR TITLE
Remove redundant service parameters

### DIFF
--- a/ecs-bluegreen-lifecycle-hooks/service_template.json
+++ b/ecs-bluegreen-lifecycle-hooks/service_template.json
@@ -18,8 +18,6 @@
     "desiredCount": 1,
     "launchType": "FARGATE",
     "deploymentConfiguration": {
-        "minimumHealthyPercent": 100,
-        "maximumPercent": 200,
         "strategy": "BLUE_GREEN",
         "bakeTimeInMinutes": 1,
         "lifecycleHooks": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`minimumHealthyPercent` and `maximumPercent` are not required for the `BLUE_GREEN` deployment strategy. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
