### PR TITLE
Add docs for modify rule

### DIFF
--- a/ecs-bluegreen-lifecycle-hooks/src/canaryFunction/app.py
+++ b/ecs-bluegreen-lifecycle-hooks/src/canaryFunction/app.py
@@ -172,6 +172,9 @@ def modify_listener_weights(prod_listener_rule_arn, actions):
     listener_arn = get_listener_arn_from_rule_arn(prod_listener_rule_arn)
     logger.info(f"Modifying listener: {listener_arn}")
 
+    # In this sample we only have one rule on our listener, the default rule.
+    # In a production environment we would expect there to be multiple rules on
+    # the listener so the modify_rules API may be more appropriate.
     try:
         modify_listener_response = elb_client.modify_listener(
             ListenerArn=listener_arn, DefaultActions=actions


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In our canary sample lifecycle hook we use the `modify_listener` API because there is only one default rule on the listener. In a production environment its more appropriate to use the `modify_rule` API as there are likely to be multiple rules on the listener. Just adding a comment to help folks reading the code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
