### PR TITLE
hookDetails callback for in_progress status

### DIFF
--- a/ecs-bluegreen-lifecycle-hooks/src/approvalFunction/app.py
+++ b/ecs-bluegreen-lifecycle-hooks/src/approvalFunction/app.py
@@ -17,12 +17,15 @@ def hook_failed():
     return {"hookStatus": "FAILED"}
 
 
-def hook_in_progress():
+def hook_in_progress(s3_bucket):
     logger.info("Sending hookStatus IN_PROGRESS back to ECS")
     return {
         "hookStatus": "IN_PROGRESS",
         "callBackDelay": 30,
-        "hookDetails": {"createServiceCheck": True},
+        "hookDetails": {
+          "createServiceCheck": True,
+          "S3_BUCKET_NAME": s3_bucket
+        }
     }
 
 
@@ -123,4 +126,4 @@ def lambda_handler(event, context):
     if file_exists:
         return hook_succeeded()
 
-    return hook_in_progress()
+    return hook_in_progress(s3_bucket)


### PR DESCRIPTION
*Issue 9:*
https://github.com/aws-samples/sample-amazon-ecs-blue-green-deployment-patterns/issues/9

*Description of changes:*
Return S3 Bucket to ECS ControlPlane during the sending of IN_PROGRESS Status


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
